### PR TITLE
Delete express dependency from basic example

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@jaredpalmer/after": "^0.5.0",
-    "express": "^4.16.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-helmet": "^5.2.0",


### PR DESCRIPTION
The basic example doesn't need express as a dependency, knowing that after.js uses it internally.