### PR TITLE
Swap fs.copyFile to fs.copy from ‘fs-extra’

### DIFF
--- a/packages/after/scripts/start.js
+++ b/packages/after/scripts/start.js
@@ -97,7 +97,7 @@ async function start() {
   chokidar
     .watch('src', { ignored: /(^|[\/\\])\../ })
     .on('change', changedPath => {
-      fs.copyFile(changedPath, tempSrc.replace('src', changedPath), err => {
+      fs.copy(changedPath, tempSrc.replace('src', changedPath), err => {
         if (err) {
           console.log(err);
         }


### PR DESCRIPTION
Fix for https://github.com/jaredpalmer/after.js/issues/60

Method fs.copyFile was added on node 8.5, use fs.copy from 'fs-extra' package instead like in other places
