### PR TITLE
Remove use of Inline JavaScript for State Transfer from SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,9 +345,10 @@ class Document extends React.Component {
           <script
             id="server-app-state"
             type="application/json"
-          >
-            {JSON.stringify(data)}
-          </script>
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(data).replace(/<\/script>/g, '%3C/script%3E')
+            }}
+          />
           <script
             type="text/javascript"
             src={assets.client.js}

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ class Document extends React.Component {
             id="server-app-state"
             type="application/json"
             dangerouslySetInnerHTML={{
-              __html: JSON.stringify(data).replace(/<\/script>/g, '%3C/script%3E')
+              __html: JSON.stringify({...data}).replace(/<\/script>/g, '%3C/script%3E')
             }}
           />
           <script

--- a/README.md
+++ b/README.md
@@ -343,11 +343,11 @@ class Document extends React.Component {
         <body {...bodyAttrs}>
           <div id="root">DO_NOT_DELETE_THIS_YOU_WILL_BREAK_YOUR_APP</div>
           <script
-            type="text/javascript"
-            dangerouslySetInnerHTML={{
-              __html: ` window.__AFTER__ = ${JSON.stringify(data)}; `
-            }}
-          />
+            id="server-app-state"
+            type="application/json"
+          >
+            {JSON.stringify(data)}
+          </script>
           <script
             type="text/javascript"
             src={assets.client.js}

--- a/packages/after/README.md
+++ b/packages/after/README.md
@@ -345,9 +345,10 @@ class Document extends React.Component {
           <script
             id="server-app-state"
             type="application/json"
-          >
-            {JSON.stringify(data)}
-          </script>
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(data).replace(/<\/script>/g, '%3C/script%3E')
+            }}
+          />
           <script
             type="text/javascript"
             src={assets.client.js}

--- a/packages/after/README.md
+++ b/packages/after/README.md
@@ -346,7 +346,7 @@ class Document extends React.Component {
             id="server-app-state"
             type="application/json"
             dangerouslySetInnerHTML={{
-              __html: JSON.stringify(data).replace(/<\/script>/g, '%3C/script%3E')
+              __html: JSON.stringify({...data}).replace(/<\/script>/g, '%3C/script%3E')
             }}
           />
           <script

--- a/packages/after/README.md
+++ b/packages/after/README.md
@@ -343,11 +343,11 @@ class Document extends React.Component {
         <body {...bodyAttrs}>
           <div id="root">DO_NOT_DELETE_THIS_YOU_WILL_BREAK_YOUR_APP</div>
           <script
-            type="text/javascript"
-            dangerouslySetInnerHTML={{
-              __html: ` window.__AFTER__ = ${JSON.stringify(data)}; `
-            }}
-          />
+            id="server-app-state"
+            type="application/json"
+          >
+            {JSON.stringify(data)}
+          </script>
           <script
             type="text/javascript"
             src={assets.client.js}

--- a/packages/after/lib/_document.js
+++ b/packages/after/lib/_document.js
@@ -28,12 +28,9 @@ class Document extends React.Component {
         </head>
         <body {...bodyAttrs}>
           <div id="root">DO_NOT_DELETE_THIS_YOU_WILL_BREAK_YOUR_APP</div>
-          <script
-            type="text/javascript"
-            dangerouslySetInnerHTML={{
-              __html: ` window.__AFTER__ = ${JSON.stringify(data)}; `,
-            }}
-          />
+          <script id="server-app-state" type="application/json">
+            {JSON.stringify(data)}
+          </script>
           <script
             type="text/javascript"
             src={assets.client.js}

--- a/packages/after/lib/_document.js
+++ b/packages/after/lib/_document.js
@@ -28,9 +28,16 @@ class Document extends React.Component {
         </head>
         <body {...bodyAttrs}>
           <div id="root">DO_NOT_DELETE_THIS_YOU_WILL_BREAK_YOUR_APP</div>
-          <script id="server-app-state" type="application/json">
-            {JSON.stringify(data)}
-          </script>
+          <script
+            id="server-app-state"
+            type="application/json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(data).replace(
+                /<\/script>/g,
+                '%3C/script%3E'
+              ),
+            }}
+          />
           <script
             type="text/javascript"
             src={assets.client.js}

--- a/packages/after/lib/_document.js
+++ b/packages/after/lib/_document.js
@@ -32,7 +32,7 @@ class Document extends React.Component {
             id="server-app-state"
             type="application/json"
             dangerouslySetInnerHTML={{
-              __html: JSON.stringify(data).replace(
+              __html: JSON.stringify({ ...data }).replace(
                 /<\/script>/g,
                 '%3C/script%3E'
               ),

--- a/packages/after/lib/client.js
+++ b/packages/after/lib/client.js
@@ -6,7 +6,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 import routes from './_routes';
 
-const data = window.__AFTER__;
+const data = JSON.parse(document.getElementById('server-app-state').innerHTML);
 
 ensureReady(routes).then(() => {
   ReactDOM.hydrate(

--- a/packages/after/lib/client.js
+++ b/packages/after/lib/client.js
@@ -6,7 +6,11 @@ import { BrowserRouter } from 'react-router-dom';
 
 import routes from './_routes';
 
-const data = JSON.parse(document.getElementById('server-app-state').innerHTML);
+const data = JSON.parse(
+  document
+    .getElementById('server-app-state')
+    .textContent.replace(/%3C\/script%3E/g, '</script>')
+);
 
 ensureReady(routes).then(() => {
   ReactDOM.hydrate(


### PR DESCRIPTION
Instead of setting out state on a window object using JavaScript, we now add JSON to the body where our bundled JavaScript can fetch. This is needed to be compliant with CSP.