### PR TITLE
Add npx starting instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ cd myapp
 yarn start
 ```
 
+If you prefer `npx`, you can create the starting template like this:
+
+```bash
+npx create-razzle app --example with-afterjs myapp
+```
+             
 Refer to [Razzle's](https://github.com/jaredpalmer/razzle) docs for tooling, babel, and webpack customization.
 
 ## Data Fetching


### PR DESCRIPTION
While following along with npm and npx, I was lost for a moment because I forgot that with npx you need to prefix the package name with `create-`, so maybe we could add the npx command to the README for those who use npm instead of yarn.