### PR TITLE
Fix readme for use with create-razzle-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ server
       const html = await render({
         req,
         res,
-        Document: MyDocument
+        document: MyDocument
         routes,
         assets,
       });

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After.js enables Next.js-like data fetching with any React SSR app that uses Rea
 You can quickly bootstrap an SSR React app with After.js using Razzle. While Razzle is not required, this documentation assumes you have the tooling setup for an isomorphic React application.
 
 ```bash
-yarn create razzle-app --example with-afterjs myapp
+create-razzle-app --example with-afterjs myapp
 cd myapp
 yarn start
 ```


### PR DESCRIPTION
I hit a couple of snags while porting my old after.js app to the "new" razzle style (new for me). Seems some docs needed updating :) 