### PR TITLE
Correct custom document example

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ server
       const html = await render({
         req,
         res,
-        Document: MyDocument
+        document: MyDocument
         routes,
         assets,
       });


### PR DESCRIPTION
Passing a property `Document` to the `render` options doesn't set a custom document component. Instead the user should pass `document` (lowercased).