### PR TITLE
change Razzle Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ After.js enables Next.js-like data fetching with any React SSR app that uses Rea
 You can quickly bootstrap an SSR React app with After.js using Razzle. While Razzle is not required, this documentation assumes you have the tooling setup for an isomorphic React application.
 
 ```bash
-yarn create razzle-app --example with-afterjs myapp
+mkdir afterjsExample
+cd afterjsExample
+yarn add create-razzle-app 
+yarn create-razzle-app --example with-afterjs myapp
 cd myapp
 yarn start
 ```
@@ -55,7 +58,7 @@ Refer to [Razzle's](https://github.com/jaredpalmer/razzle) docs for tooling, bab
 ## Data Fetching
 
 For page components, you can add a `static async getInitialProps` function.
-This will be called on both initial server render, and then client mounts.
+This will be called on both initial server render, and then client mounts.`
 Results are made available on `this.props`.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Refer to [Razzle's](https://github.com/jaredpalmer/razzle) docs for tooling, bab
 ## Data Fetching
 
 For page components, you can add a `static async getInitialProps` function.
-This will be called on both initial server render, and then client mounts.`
+This will be called on both initial server render, and then client mounts.
 Results are made available on `this.props`.
 
 ```js


### PR DESCRIPTION
first of all, thank you for your project :)
when i first start this framework, specially "Quick Start", It was not running.
like this screen shot.
![image](https://user-images.githubusercontent.com/18342572/36350061-1307bc74-14d4-11e8-9f5f-071d66b6767e.png)
I don't know nextJS, razzle, yarn. so I was found solution. 
I guess razzle was changed "create razzle-app" to "create-razzle-app" 
so i try to "yarn add create-razzle-app" and then" yarn create-razzle-app".
It is running.
I wish you are accept this PR.

