### PR TITLE
Make customRenderer optional

### DIFF
--- a/src/render.tsx
+++ b/src/render.tsx
@@ -23,7 +23,7 @@ export type AfterRenderProps<T> = T & {
   req: any;
   res: any;
   assets: any;
-  customRenderer: Function;
+  customRenderer?: Function;
   routes: Partial<RouteProps>[];
   document?: React.ComponentType<any>;
 };


### PR DESCRIPTION
Right now customRenderer is typed as if it is required, so if you don't provide one, typescript emits an error.

I marked it as optional.