### PR TITLE
Fix: Route location & Prevent multiple renders

### DIFF
--- a/src/After.tsx
+++ b/src/After.tsx
@@ -18,10 +18,9 @@ class Afterparty extends React.Component<any, any> {
     const navigated = nextProps.location !== this.props.location;
     if (navigated) {
       window.scrollTo(0, 0);
-      // save the location so we can render the old screen
-      // and keep the data so the render won't break
+      // save the location so we can trigger a shouldComponentUpdate lifecycle
       this.setState({
-        previousLocation: this.props.location,
+        previousLocation: this.props.location
       });
       const { data, match, routes, history, location, ...rest } = nextProps;
       loadInitialProps(this.props.routes, nextProps.location.pathname, {
@@ -37,6 +36,10 @@ class Afterparty extends React.Component<any, any> {
           console.log(e);
         });
     }
+  }
+
+  shouldComponentUpdate(nextProps: any, nextState: any) {
+    return !nextState.previousLocation;
   }
 
   prefetch = (pathname: string) => {

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -19,9 +19,9 @@ class Afterparty extends React.Component<any, any> {
     if (navigated) {
       window.scrollTo(0, 0);
       // save the location so we can render the old screen
+      // and keep the data so the render won't break
       this.setState({
         previousLocation: this.props.location,
-        data: undefined, // unless you want to keep it
       });
       const { data, match, routes, history, location, ...rest } = nextProps;
       loadInitialProps(this.props.routes, nextProps.location.pathname, {
@@ -56,7 +56,7 @@ class Afterparty extends React.Component<any, any> {
     const { location } = this.props;
     const initialData = this.prefetcherCache[location.pathname] || data;
     return (
-      <Switch>
+      <Switch location={previousLocation || location}>
         {this.props.routes.map((r: any, i: number) => (
           <Route
             key={`route--${i}`}
@@ -67,7 +67,6 @@ class Afterparty extends React.Component<any, any> {
               React.createElement(r.component, {
                 ...initialData,
                 history: props.history,
-                location: previousLocation || location,
                 match: props.match,
                 prefetch: this.prefetch,
               })


### PR DESCRIPTION
After a long debugging session and try to understand what was going on, I figure it out the following issues:
- Per [React Router documentation](https://reacttraining.com/react-router/web/api/Route/location-object), the `location` prop is being overriden by the `<Switch>` component. This was causing a render of the new location without the `getInitialProps` being fired.
> If a <Route> element is wrapped in a <Switch> and matches the location passed to the <Switch> (or the current history location), then the location prop passed to <Route> will be overridden by the one used by the <Switch> (given here).
- The _componentWillReceiveProps_ lifecycle is firing multiple render that, in my opinion, are not necessary. I added the _shouldComponentUpdate_ which only enable a re-render of the component when the `this.state.previousLocation` is null, which means a new location route is navigated and we already have the `getInitialProps` fired.