### PR TITLE
Fix: don't remove data for previous location

### DIFF
--- a/src/After.tsx
+++ b/src/After.tsx
@@ -21,7 +21,7 @@ class Afterparty extends React.Component<any, any> {
       // save the location so we can render the old screen
       this.setState({
         previousLocation: this.props.location,
-        data: undefined, // unless you want to keep it
+        data: this.state.data
       });
       const { data, match, routes, history, location, ...rest } = nextProps;
       loadInitialProps(this.props.routes, nextProps.location.pathname, {


### PR DESCRIPTION
Hello,

Thanks for this nice library!

I need to check props when the previous route renders without any data, that's not conveniently.

```js
const Report = ({ report }) => 
  report &&
    report.images.map(image => (
      <Image key={image.src} />
    ))
```

If the request is already in browser's cache the page is blinking awful when it rerenders without data.

![blinking ui](https://ucarecdn.com/9e1aba1a-2a3f-49cc-bff3-67b2f028c256/video.gif)

I am suggesting one pros: to detect data loading and react on it. Maybe we should do separate flag and inject it as `prefetch` method

I think it will be better to render previous route with it's data that was already fetched
