### PR TITLE
Fix custom args passed to getInitialProps()

### DIFF
--- a/src/render.tsx
+++ b/src/render.tsx
@@ -81,6 +81,7 @@ export async function render<T>(options: AfterRenderProps<T>) {
     assets,
     renderPage,
     data,
+    ...rest, // pass other custom user-defined props
     match: reactRouterMatch,
   });
 


### PR DESCRIPTION
In the Readme, it's stated that After's `render()` function will pass custom args to the `getInitialProps()` of the document. This is called `customThing: 'thing'` in the basic example. This functionality is broken and this PR fixes it. See https://github.com/jaredpalmer/after.js/issues/156