### PR TITLE
remove any from AfterRenderOptions

### DIFF
--- a/src/After.tsx
+++ b/src/After.tsx
@@ -32,7 +32,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
   }
 
   // only runs clizzient
-  componentWillReceiveProps(nextProps: AfterpartyProps, nextState: AfterpartyState) {
+  componentWillReceiveProps(nextProps: AfterpartyProps) {
     const navigated = nextProps.location !== this.props.location;
     if (navigated) {
       window.scrollTo(0, 0);

--- a/src/Document.tsx
+++ b/src/Document.tsx
@@ -3,7 +3,7 @@ import serialize from 'serialize-javascript';
 import { DocumentProps } from './types';
 
 export class Document extends React.Component<DocumentProps> {
-  static async getInitialProps({ assets, data, renderPage }: DocumentProps) {
+  static async getInitialProps({ assets, data, renderPage }: Partial<DocumentProps> & Pick<Required<DocumentProps>, 'renderPage'>) {
     const page = await renderPage();
     return { assets, data, ...page };
   }

--- a/src/asyncComponent.tsx
+++ b/src/asyncComponent.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { Module, AsyncRouteableComponent } from './types';
 
-export interface AsyncRouteComponentProps {
-  isInitialRender: boolean;
-  setAppState: (data: any) => void;
-}
-
 export interface AsyncRouteComponentState {
   Component: AsyncRouteableComponent |  null;
 }
@@ -19,7 +14,7 @@ export function asyncComponent<Props>({
   loader,
   Placeholder
 }: {
-  loader: () => Promise<Module<React.ReactElement<Props>>>;
+  loader: () => Promise<Module<React.ComponentType<Props>>>;
   Placeholder?: React.ComponentType<Props>;
 }) {
   let Component: AsyncRouteableComponent<Props> | null = null; // keep Component in a closure to avoid doing this stuff more than once

--- a/src/ensureReady.ts
+++ b/src/ensureReady.ts
@@ -9,7 +9,7 @@ export async function ensureReady(routes: AsyncRouteProps[], pathname?: string) 
     routes.map(route => {
       const match = matchPath(pathname || window.location.pathname, route);
       if (match && route && route.component && route.component.load) {
-        return (route.component as any).load();
+        return (route.component).load();
       }
       return undefined;
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,25 +1,29 @@
-import { RouteProps, RouteComponentProps } from 'react-router-dom';
+import { RouteProps, RouteComponentProps, match as Match } from 'react-router-dom';
 import { HelmetData} from 'react-helmet';
+import {Request, Response} from 'express';
 
 export interface DocumentProps {
+  req: Request;
+  res: Response;
   helmet: HelmetData;
   assets: Assets;
   data: Promise<any>[];
   renderPage: () => Promise<any>;
+  match: Match<any> | null;
 }
 
-export interface RouteComponent {
+export interface AsyncRouteComponent {
   getInitialProps: ({ assets, data, renderPage }: DocumentProps) => any;
   load: () => Promise<React.ReactNode>;
 }
 
 export type AsyncRouteableComponent<Props = any> =
-| React.ComponentType<RouteComponentProps<Props>> & RouteComponent
-| React.ComponentType<any> & RouteComponent;
+| React.ComponentType<RouteComponentProps<Props>> & AsyncRouteComponent
+| React.ComponentType<any> & AsyncRouteComponent;
 
 export interface AsyncRouteProps<Props = any> extends RouteProps {
   component: AsyncRouteableComponent<Props>;
-  redirectTo: string;
+  redirectTo?: string;
 }
 
 export interface InitialProps {


### PR DESCRIPTION
I've removed the any from render options:

```
export async function render<T>(options: AfterRenderOptions<T>) {
  const { req, res, routes, assets, document: Document, customRenderer, ...rest } = options;
````

One thing I am not sure about is I've added `helmet`  [here](https://github.com/dagda1/after.js/blob/after-render-options/src/render.tsx#L78) in `render` as now `helmet` is required.  Is this correct do you think?