### PR TITLE
Fix: browser error on deserializing a state with Date

### DIFF
--- a/src/Document.tsx
+++ b/src/Document.tsx
@@ -46,7 +46,7 @@ export function AfterData({ data }: any) {
       id="server-app-state"
       type="application/json"
       dangerouslySetInnerHTML={{
-        __html: serialize({ ...data }).replace(/<\/script>/g, '%3C/script%3E')
+        __html: serialize({ ...data })
       }}
     />
   );

--- a/src/ensureReady.ts
+++ b/src/ensureReady.ts
@@ -17,9 +17,8 @@ export async function ensureReady(routes: AsyncRouteProps[], pathname?: string) 
 
   let data;
   if (typeof window !== undefined && !!document) {
-    data = JSON.parse(
-      (document as any).getElementById('server-app-state').textContent
-    );
+    // deserialize state from 'serialize-javascript' format
+    data = eval('(' + (document as any).getElementById('server-app-state').textContent + ')');
   }
   return Promise.resolve(data);
 }


### PR DESCRIPTION
JSON.parse was exploding when parsing a data object that contains a Date.

1. The serialized string is not always a valid JSON - it must be deserialized as per https://github.com/yahoo/serialize-javascript docs. 
2. Replacing closing script tag is not required - this is handled by serialize-javascript.