### PR TITLE
make options optional for render

### DIFF
--- a/src/After.tsx
+++ b/src/After.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Switch, Route, withRouter, match as Match } from 'react-router-dom';
 import { loadInitialProps } from './loadInitialProps';
-import {History, Location} from 'history';
+import { History, Location } from 'history';
 import { AsyncRouteProps } from './types';
 
 export interface AfterpartyProps {

--- a/src/Document.tsx
+++ b/src/Document.tsx
@@ -3,8 +3,9 @@ import serialize from 'serialize-javascript';
 import { DocumentProps } from './types';
 
 export class Document extends React.Component<DocumentProps> {
-  static async getInitialProps({ assets, data, renderPage }: Partial<DocumentProps> & Pick<Required<DocumentProps>, 'renderPage'>) {
+  static async getInitialProps({ assets, data, renderPage }: DocumentProps) {
     const page = await renderPage();
+
     return { assets, data, ...page };
   }
 

--- a/src/asyncComponent.tsx
+++ b/src/asyncComponent.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { Module, AsyncRouteableComponent } from './types';
-
-export interface AsyncRouteComponentState {
-  Component: AsyncRouteableComponent |  null;
-}
+import { Module, AsyncRouteComponentState, AsyncRouteComponentType } from './types';
 
 /**
  * Returns a new React component, ready to be instantiated.
@@ -17,7 +13,8 @@ export function asyncComponent<Props>({
   loader: () => Promise<Module<React.ComponentType<Props>>>;
   Placeholder?: React.ComponentType<Props>;
 }) {
-  let Component: AsyncRouteableComponent<Props> | null = null; // keep Component in a closure to avoid doing this stuff more than once
+  // keep Component in a closure to avoid doing this stuff more than once
+  let Component: AsyncRouteComponentType<Props> | null = null;
 
   return class AsyncRouteComponent extends React.Component<Props, AsyncRouteComponentState> {
     /**

--- a/src/ensureReady.ts
+++ b/src/ensureReady.ts
@@ -1,5 +1,6 @@
 import { matchPath } from 'react-router-dom';
 import { AsyncRouteProps } from './types';
+import { isAsyncComponent } from './utils';
 
 /**
  * This helps us to make sure all the async code is loaded before rendering.
@@ -8,8 +9,8 @@ export async function ensureReady(routes: AsyncRouteProps[], pathname?: string) 
   await Promise.all(
     routes.map(route => {
       const match = matchPath(pathname || window.location.pathname, route);
-      if (match && route && route.component && route.component.load) {
-        return (route.component).load();
+      if (match && route && route.component && isAsyncComponent(route.component) && route.component.load) {
+        return route.component.load();
       }
       return undefined;
     })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,3 +4,4 @@ export * from './Document';
 export * from './ensureReady';
 export * from './loadInitialProps';
 export * from './render';
+export * from './types';

--- a/src/loadInitialProps.tsx
+++ b/src/loadInitialProps.tsx
@@ -1,5 +1,6 @@
 import { matchPath } from 'react-router-dom';
-import { AsyncRouteProps, InitialProps } from './types';
+import { AsyncRouteProps, InitialProps, AsyncRouteComponentType } from './types';
+import { isAsyncComponent } from './utils';
 
 export async function loadInitialProps(routes: AsyncRouteProps[], pathname: string, ctx: any): Promise<InitialProps> {
   const promises: Promise<any>[] = [];
@@ -7,11 +8,13 @@ export async function loadInitialProps(routes: AsyncRouteProps[], pathname: stri
   const match = routes.find((route: AsyncRouteProps) => {
     const matched = matchPath(pathname, route);
 
-    if (matched && route.component && route.component.getInitialProps) {
+    if (matched && route.component && isAsyncComponent(route.component)) {
+      const component = route.component as AsyncRouteComponentType<any>;
+
       promises.push(
-        route.component.load
-          ? route.component.load().then(() => route.component.getInitialProps({ matched, ...ctx }))
-          : route.component.getInitialProps({ matched, ...ctx })
+        component.load
+          ? component.load().then(() => component.getInitialProps({ matched, ...ctx }))
+          : component.getInitialProps({ matched, ...ctx })
       );
     }
 

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -8,14 +8,15 @@ import { loadInitialProps } from './loadInitialProps';
 import * as utils from './utils';
 import * as url from 'url';
 import { Request, Response } from 'express';
-import { Assets, AsyncRouteProps, DocumentProps, AsyncRouteComponent } from './types';
+import { Assets, AsyncRouteProps, AsyncRouteComponentType } from './types';
 
 const modPageFn = function<Props>(Page: React.ComponentType<Props>) {
   return (props: Props) => <Page {...props} />;
 };
 
 /*
- The customRenderer parameter is a (potentially async) function that can be set to return more than just a rendered string.
+ The customRenderer parameter is a (potentially async) function that can be set to return 
+ more than just a rendered string.
  If present, it will be used instead of the default ReactDOMServer renderToString function.
  It has to return an object of shape { html, ... }, in which html will be used as the rendered string
  Other props will be also pass to the Document component
@@ -25,13 +26,14 @@ export interface AfterRenderOptions<T> {
   res: Response;
   assets: Assets;
   routes: AsyncRouteProps[];
-  document: React.ComponentType<DocumentProps> & AsyncRouteComponent;
-  customRenderer: (element: React.ReactElement<T>) => ({hthl: string});
+  document?: AsyncRouteComponentType<T> | typeof DefaultDoc;
+  customRenderer?: (element: React.ReactElement<T>) => { hthl: string };
 }
 
 export async function render<T>(options: AfterRenderOptions<T>) {
   const { req, res, routes, assets, document: Document, customRenderer, ...rest } = options;
   const Doc = Document || DefaultDoc;
+
   const context = {};
   const renderPage = async (fn = modPageFn) => {
     // By default, we keep ReactDOMServer synchronous renderToString function
@@ -77,7 +79,7 @@ export async function render<T>(options: AfterRenderOptions<T>) {
     data,
     helmet: Helmet.renderStatic(),
     match: reactRouterMatch,
-    ...rest,
+    ...rest
   });
 
   const doc = ReactDOMServer.renderToStaticMarkup(<Doc {...docProps} />);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { RouteProps, RouteComponentProps, match as Match } from 'react-router-dom';
-import { HelmetData} from 'react-helmet';
-import {Request, Response} from 'express';
+import { HelmetData } from 'react-helmet';
+import { Request, Response } from 'express';
 
 export interface DocumentProps {
   req: Request;
@@ -12,14 +12,27 @@ export interface DocumentProps {
   match: Match<any> | null;
 }
 
-export interface AsyncRouteComponent {
-  getInitialProps: ({ assets, data, renderPage }: DocumentProps) => any;
-  load: () => Promise<React.ReactNode>;
+export interface AsyncRouteComponentState {
+  Component: AsyncRouteableComponent | null;
 }
 
+export interface AsyncComponent {
+  getInitialProps: (props: DocumentProps) => any;
+  load?: () => Promise<React.ReactNode>;
+}
+
+export interface AsyncRouteComponent<Props = {}>
+  extends AsyncComponent,
+    React.Component<DocumentProps & Props, AsyncRouteComponentState> {}
+
+export type AsyncRouteComponentType<Props> =
+  | React.ComponentClass<Props> & AsyncComponent
+  | React.StatelessComponent<Props> & AsyncComponent;
+
 export type AsyncRouteableComponent<Props = any> =
-| React.ComponentType<RouteComponentProps<Props>> & AsyncRouteComponent
-| React.ComponentType<any> & AsyncRouteComponent;
+  | AsyncRouteComponentType<RouteComponentProps<Props>>
+  | React.ComponentType<RouteComponentProps<Props>>
+  | React.ComponentType<Props>;
 
 export interface AsyncRouteProps<Props = any> extends RouteProps {
   component: AsyncRouteableComponent<Props>;
@@ -32,17 +45,17 @@ export interface InitialProps {
 }
 
 export type Module<P> =
-| {
-    default?: P;
-    [x: string]: any;
-  }
-| {
-    exports?: P;
-    [x: string]: any;
-  };
+  | {
+      default?: P;
+      [x: string]: any;
+    }
+  | {
+      exports?: P;
+      [x: string]: any;
+    };
 
 export interface Assets {
   [name: string]: {
-      [ext: string]: string;
+    [ext: string]: string;
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { AsyncRouteableComponent, AsyncRouteComponentType } from "./types";
+
 /** @private is the given object a Function? */
 export const isFunction = (obj: any) => 'function' === typeof obj;
 
@@ -7,3 +9,8 @@ export const isObject = (obj: any) => obj !== null && typeof obj === 'object';
 /** @private is the given object/value a promise? */
 export const isPromise = (value: any): boolean =>
   isObject(value) && isFunction(value.then);
+
+/** @private Guard cluase to narrow the AsyncRouteableComponent union type */
+export function isAsyncComponent(Component: AsyncRouteableComponent): Component is AsyncRouteComponentType<any> {
+  return (<AsyncRouteComponentType<any>>Component).load !== undefined;
+}


### PR DESCRIPTION
I noticed a few things when trying to use this in an actual typescript project.

I've made document and customRenderer optionals in `AfterRenderOptions`:

```

export interface AfterRenderOptions<T> {
  req: Request;
  res: Response;
  assets: Assets;
  routes: AsyncRouteProps[];
  document?: AsyncRouteComponentType<T> | typeof DefaultDoc;
  customRenderer?: (element: React.ReactElement<T>) => { hthl: string };
}
```

Also exported the `types`.  I probably need to name things better in that file but this is better for n ow.