### PR TITLE
resolve non default module exports

### DIFF
--- a/src/asyncComponent.tsx
+++ b/src/asyncComponent.tsx
@@ -24,7 +24,9 @@ export function asyncComponent<Props>({
      */
     static load() {
       return loader().then((ResolvedComponent) => {
-        Component = ResolvedComponent!.default || ResolvedComponent;
+        const keys = Object.keys(ResolvedComponent);
+
+        Component = ResolvedComponent.default || (keys.length && ResolvedComponent[keys[0]]) || ResolvedComponent;
       });
     }
 


### PR DESCRIPTION
Allow non named modules to be resolved.  I am not a fan of default exports so I've added the following code to check for a named import if a default one is not provided:
```
    static load() {
      return loader().then((ResolvedComponent) => {
        const keys = Object.keys(ResolvedComponent);

        Component = ResolvedComponent.default || (keys.length && ResolvedComponent[keys[0]]) || ResolvedComponent;
      });
    }
```

