### PR TITLE
change examples basic references to the build folder and not the npm package

### DIFF
--- a/examples/basic/src/client.js
+++ b/examples/basic/src/client.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { hydrate } from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
-import { ensureReady, After } from '@jaredpalmer/after';
+import { ensureReady, After } from '../../../build';
 import './client.css';
 import routes from './routes';
 

--- a/examples/basic/src/routes.js
+++ b/examples/basic/src/routes.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { asyncComponent } from '@jaredpalmer/after';
+import { asyncComponent } from '../../../build/asyncComponent';
 
 export default [
   {

--- a/examples/basic/src/server.js
+++ b/examples/basic/src/server.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { render } from '@jaredpalmer/after';
+import { render } from '../../../build';
 import routes from './routes';
 
 const assets = require(process.env.RAZZLE_ASSETS_MANIFEST);


### PR DESCRIPTION
Until there are tests, it is better if `examples/basic` references the built source and not the npm package.