### PR TITLE
layout component to wrap routes

### DIFF
--- a/src/After.tsx
+++ b/src/After.tsx
@@ -10,6 +10,7 @@ export interface AfterpartyProps extends RouteComponentProps<any> {
   data?: Promise<any>[];
   routes: AsyncRouteProps[];
   match: Match<any>;
+  Layout?: React.ComponentType<{ location: Location; children: React.ReactNode }>;
 }
 
 export interface AfterpartyState {
@@ -74,11 +75,11 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
 
   render() {
     const { previousLocation, data } = this.state;
-    const { location } = this.props;
+    const { location, Layout } = this.props;
     const initialData = this.prefetcherCache[location.pathname] || data;
 
-    return (
-      <Switch>
+    const content = (
+      <Switch location={location}>
         {this.props.routes.map((r, i) => (
           <Route
             key={`route--${i}`}
@@ -98,6 +99,11 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
         ))}
       </Switch>
     );
+    if (Layout) {
+      return <Layout location={location}>{content}</Layout>;
+    } else {
+      return content;
+    }
   }
 }
 export const After = withRouter(Afterparty);

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Switch, Route, withRouter, match as Match, RouteComponentProps } from 'react-router-dom';
 import { loadInitialProps } from './loadInitialProps';
 import { History, Location } from 'history';
-import { AsyncRouteProps } from './types';
+import { AsyncRouteProps, LayoutComponent } from './types';
 
 export interface AfterpartyProps extends RouteComponentProps<any> {
   history: History;
@@ -10,7 +10,7 @@ export interface AfterpartyProps extends RouteComponentProps<any> {
   data?: Promise<any>[];
   routes: AsyncRouteProps[];
   match: Match<any>;
-  Layout?: React.ComponentType<{ location: Location; children: React.ReactNode }>;
+  Layout?: LayoutComponent;
 }
 
 export interface AfterpartyState {
@@ -43,17 +43,17 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
         data: undefined // unless you want to keep it
       });
 
-      const { data, match, routes, history, location, staticContext, ...rest } = nextProps;
+      const { data, match, routes, history, location, staticContext, Layout, ...rest } = nextProps;
 
       loadInitialProps(this.props.routes, nextProps.location.pathname, {
         location: nextProps.location,
         history: nextProps.history,
         ...rest
       })
-        .then(({ data }) => {
+        .then(({ data }: { data: any }) => {
           this.setState({ previousLocation: null, data });
         })
-        .catch((e) => {
+        .catch((e: any) => {
           // @todo we should more cleverly handle errors???
           console.log(e);
         });

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -8,7 +8,7 @@ import { loadInitialProps } from './loadInitialProps';
 import * as utils from './utils';
 import * as url from 'url';
 import { Request, Response } from 'express';
-import { Assets, AsyncRouteProps } from './types';
+import { Assets, AsyncRouteProps, LayoutComponent } from './types';
 
 const modPageFn = function<Props>(Page: React.ComponentType<Props>) {
   return (props: Props) => <Page {...props} />;
@@ -27,10 +27,7 @@ export interface AfterRenderOptions<T> {
   assets: Assets;
   routes: AsyncRouteProps[];
   document?: typeof DefaultDoc;
-  layout?: React.ComponentType<{ 
-    location: Location; 
-    children: React.ReactNode 
-  }>;
+  layout?: LayoutComponent;
   customRenderer?: (element: React.ReactElement<T>) => { hthl: string };
 }
 

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -27,11 +27,15 @@ export interface AfterRenderOptions<T> {
   assets: Assets;
   routes: AsyncRouteProps[];
   document?: typeof DefaultDoc;
+  layout?: React.ComponentType<{ 
+    location: Location; 
+    children: React.ReactNode 
+  }>;
   customRenderer?: (element: React.ReactElement<T>) => { hthl: string };
 }
 
 export async function render<T>(options: AfterRenderOptions<T>) {
-  const { req, res, routes, assets, document: Document, customRenderer, ...rest } = options;
+  const { req, res, routes, assets, document: Document, layout: Layout, customRenderer, ...rest } = options;
   const Doc = Document || DefaultDoc;
 
   const context = {};
@@ -41,7 +45,7 @@ export async function render<T>(options: AfterRenderOptions<T>) {
     const renderer = customRenderer || defaultRenderer;
     const asyncOrSyncRender = renderer(
       <StaticRouter location={req.url} context={context}>
-        {fn(After)({ routes, data })}
+        {fn(After)({ routes, data, Layout })}
       </StaticRouter>
     );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,13 @@ import { Request, Response } from 'express';
 import { IncomingMessage, ServerResponse } from 'http';
 import { History, Location } from 'history';
 
+export interface LayoutProps { 
+  location: Location; 
+  children: React.ReactNode 
+}
+
+export type LayoutComponent = React.ComponentClass<LayoutProps>
+
 export interface DocumentProps {
   req: Request;
   res: Response;


### PR DESCRIPTION
As described in #172 it would be useful to have a way to pass a component that wraps around the Routes, to implement custom route transitions and enable setting things like headers that appear on all pages. 

See example usage: 
https://github.com/MrLoh/afterjs-apollo-rnw-styled-pose-example/tree/layout