### PR TITLE
Enable passing custom context object to StaticRouter

### DIFF
--- a/src/render.tsx
+++ b/src/render.tsx
@@ -15,7 +15,7 @@ const modPageFn = function<Props>(Page: React.ComponentType<Props>) {
 };
 
 /*
- The customRenderer parameter is a (potentially async) function that can be set to return 
+ The customRenderer parameter is a (potentially async) function that can be set to return
  more than just a rendered string.
  If present, it will be used instead of the default ReactDOMServer renderToString function.
  It has to return an object of shape { html, ... }, in which html will be used as the rendered string
@@ -28,13 +28,13 @@ export interface AfterRenderOptions<T> {
   routes: AsyncRouteProps[];
   document?: typeof DefaultDoc;
   customRenderer?: (element: React.ReactElement<T>) => { html: string };
+  context: {};
 }
 
 export async function render<T>(options: AfterRenderOptions<T>) {
-  const { req, res, routes, assets, document: Document, customRenderer, ...rest } = options;
+  const { req, res, routes, assets, document: Document, customRenderer, context = {}, ...rest } = options;
   const Doc = Document || DefaultDoc;
 
-  const context = {};
   const renderPage = async (fn = modPageFn) => {
     // By default, we keep ReactDOMServer synchronous renderToString function
     const defaultRenderer = (element: React.ReactElement<T>) => ({ html: ReactDOMServer.renderToString(element) });


### PR DESCRIPTION
The intention of this PR is to enable passing custom context object to StaticRouter used in render.js.

By enabling passing context object user could read those values from code that is using After.js(server logic).

Redirect component from ReactRouter use StaticRouter context to set `url` property so the request can be redirected on a server. They recommend using context object for other cases as well.

My intention is to use context to set up a custom status code(404) inside the React component(NotFoundPage) on server render.

Example: 

```javascript
 const context = {};

 const response = await render({
        req,
        res,
        routes,
        assets,
        customRenderer,
        document: Document,
        context,
  });
   if (context.statusCode) {
         res.status(context.statusCode);
    }
    res.send(response);
```


```javascript
/* StatusCode.js  */
const StatusCode = ({ code, children }) => {
    return (
        <Route
            render={({ staticContext }) => {
                if (staticContext) {
                    staticContext.statusCode = code;
                }
                return children;
            }}
        />
    );
};

/* NotFoundPage.js  */
cont NotFoundPage = () => (
     <StatusCode code="404">
           Page is not found, 404
      </StatusCode>
);

```




