### PR TITLE
Fix data fetching (🚀 SUSPENSE but not suspense 🚀)

### DIFF
--- a/src/After.tsx
+++ b/src/After.tsx
@@ -90,7 +90,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
   render() {
     const { previousLocation, data } = this.state;
     const { location } = this.props;
-    const initialData = this.prefetcherCache[location.pathname] || data;
+     const initialData = this.prefetcherCache[(previousLocation || location).pathname] || data;
 
     return (
       <Switch location={previousLocation || location}>

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -105,6 +105,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
               React.createElement(r.component, {
                 ...initialData,
                 history: props.history,
+                location: previousLocation || location,
                 match: props.match,
                 prefetch: this.prefetch
               })

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -101,7 +101,6 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
             key={`route--${i}`}
             path={r.path}
             exact={r.exact}
-            location={previousLocation || location}
             render={(props) =>
               React.createElement(r.component, {
                 ...initialData,

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -40,8 +40,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
     if (navigated) {
       // save the location so we can render the old screen
       this.setState({
-        previousLocation: this.props.location,
-        data: undefined // unless you want to keep it
+        previousLocation: this.state.previousLocation || this.props.location,
       });
 
       const { data, match, routes, history, location, staticContext, ...rest } = nextProps;
@@ -52,6 +51,11 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
         ...rest
       })
         .then(({ data }) => {
+          
+          if (location !== nextProps.location) {
+            return  
+          }
+
           // Only for page changes, prevent scroll up for anchor links
           if (
             (this.state.previousLocation &&
@@ -88,7 +92,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
     const initialData = this.prefetcherCache[location.pathname] || data;
 
     return (
-      <Switch>
+      <Switch location={previousLocation || location}>
 				{initialData && initialData.statusCode && initialData.statusCode === 404 && <Route component={this.NotfoundComponent} path={location.pathname} />}
 				{initialData && initialData.redirectTo && initialData.redirectTo && <Redirect to={initialData.redirectTo} />}
         {getAllRoutes(this.props.routes).map((r, i) => (
@@ -101,7 +105,6 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
               React.createElement(r.component, {
                 ...initialData,
                 history: props.history,
-                location: previousLocation || location,
                 match: props.match,
                 prefetch: this.prefetch
               })

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -44,6 +44,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
         previousLocation: this.state.previousLocation || this.props.location,
       });
 
+      const { location: currentLocation } = this.props
       const { data, match, routes, history, location, staticContext, ...rest } = nextProps;
 
       loadInitialProps(this.props.routes, nextProps.location.pathname, {
@@ -53,7 +54,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
       })
         .then(({ data }) => {
           // if data is not for current location just don't do anything
-          if (location !== nextProps.location) {
+          if (currentLocation !== nextProps.location) {
             return  
           }
 

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -38,7 +38,8 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
   componentWillReceiveProps(nextProps: AfterpartyProps) {
     const navigated = nextProps.location !== this.props.location;
     if (navigated) {
-      // save the location so we can render the old screen
+      // save the location and data so we can render the old screen
+      // first we try to use previousLocation and then location from props
       this.setState({
         previousLocation: this.state.previousLocation || this.props.location,
       });
@@ -51,7 +52,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
         ...rest
       })
         .then(({ data }) => {
-          
+          // if data is not for current location just don't do anything
           if (location !== nextProps.location) {
             return  
           }


### PR DESCRIPTION
When a user moves from page `/a` to page `/b`, `<After />` calls `getInitialProps` method for that page. (as expected)

## Current Behavior

URL Change  -> `getInitialProps` get called -> matched component get renderd on screen -> `getInitialProps` resolved -> component gets re-renered and can acess `getInitialProps` data from it's props  

this is very bad and there are some problems:
1. very bad UX, this will cause page jank since matched component gets rendered on-screen without any data, and we have to show `<Spinner />` till `getInitialProps` resolved
2.  scroll to top happen after `getInitialProps` resolved, so the user will see nothing (or footer) for a while
3. if we use data from `getInitialProps` with hooks, we have to write very complicated code
```jsx
function PageB({ data }) 
  const [count, setCount] = React.useState(data)

  if (!data) return <Spinner />

  return <span>{count}</span>
}

PageB.getInitialProps = () => {
  return new Promise(reslove => setTimeout(() => reslove({ data: 1 }) , 3000))
}
```
`data` is undefined so count is undefined, and to fix it we have to write an effect like below:

```jsx
React.useEffect(() => {
  setCount(data)
}, [ data ])

```
![not-concurrent](https://user-images.githubusercontent.com/25016067/68108328-ba296700-fefc-11e9-819a-db76c8d2f92e.gif)

## Desired Behavior

URL Change  -> `getInitialProps` get called -> `<After />` wait's on current location until `getInitialProps` resolved -> render matched component with data from `getInitialProps`

user can interact with prev page since the new page data is going to fetch.

When a user moves from page `/a` to page `/b`, URL changes but the user still sees `/a` page on the screen till `/b` page data get fetched.
![concurrent](https://user-images.githubusercontent.com/25016067/68108311-b09fff00-fefc-11e9-90fc-287feeb9f360.gif)

@jaredpalmer  missed a point about react-router-dom documentation. 

as [react-router-dom said:](https://reacttraining.com/react-router/web/api/Route/location-object)

> If a `<Route>` element is wrapped in a `<Switch>` and matches the location passed to the `<Switch>` (or the current history location), then the location prop passed to `<Route>` will be overridden by the one used by the `<Switch>`

and this is part of `After` component logic: 
```jsx
<Switch>
  {routes.map((r, i) => (
    <Route
      key={`route--${i}`}
      path={r.path}
      exact={r.exact}
      location={previousLocation || location} // <- ignored because `<Route>` wrapped inside `<Switch>`
      render={(props) =>
        React.createElement(r.component, {
          ...initialData,
          history: props.history,
          location: previousLocation || location,
          match: props.match,
          prefetch: this.prefetch
        })
      }
    />
  ))}
</Switch>
```

fix:
```jsx
<Switch location={previousLocation || location}> {/* <- this will work */}
  {routes.map((r, i) => (
    <Route
      key={`route--${i}`}
      path={r.path}
      exact={r.exact}
      render={(props) =>
        React.createElement(r.component, {
          ...initialData,
          history: props.history,
          location: previousLocation || location,
          match: props.match,
          prefetch: this.prefetch
        })
      }
    />
  ))}
</Switch>
```
## Bugs

if we want to render the old screen we must keep its data. if we set `data` to `undefined` component re-rendered without that prop so it will break our component.
if we have a component like this:
```jsx
function PageB({ data }) {
  return <span>hello, {data.name}</span>
}

PageB.getInitialProps = () => {
  return new Promise(reslove =>
    setTimeout(() => reslove({ data: { name: 'Nima Arefi' } }), 3000)
  );
}
```

in current implementation when browser URL changes, `<After>` sets `data` to `undefined` then it calls `getInitialProps`. from that moment we `setState({ data: undefined })` to that moment `getInitialProps` get resolved, old screen rendered without any props and it will break our app ... 

change:
```jsx
componentWillReceiveProps(nextProps: AfterpartyProps) {
  const navigated = nextProps.location !== this.props.location;
  if (navigated) {
    // save the location so we can render the old screen
    this.setState({
      previousLocation: this.props.location,
      data: undefined // unless you want to keep it
    });
```
to: 
```jsx
componentWillReceiveProps(nextProps: AfterpartyProps) {
  const navigated = nextProps.location !== this.props.location;
  if (navigated) {
    // save the location and data so we can render the old screen
    this.setState({
      previousLocation: this.props.location,
    });
```

but things get complicated when URL changes two times (while the first one is pending), I will explain this with an example:

The user is in the "/" route, then he/she clicks on a `<Link>` and URL changes to `/post/1`.
it will take 1 second to `/post/1` page data fetched, while data is going to fetch (Promise is pending) user decide to click on another `<Link>` and URL changes to `/shop`. (and our app will break)

### Why
because we save location (location for `/post/1`) as `previousLocation` and then we render `/post/1` on screen. but `getInitialProps` for `/post/1` is still pending and data is not ready. if we render that component on-screen, the component will break since props needed for the component (the result of `getInitialProps`) are undefined.
 
```jsx
componentWillReceiveProps(nextProps: AfterpartyProps) {
  const navigated = nextProps.location !== this.props.location;
  if (navigated) {
    // save the location and data so we can render the old screen
    this.setState({
      previousLocation: this.props.location,
    });
```

to fix this we have to check if `previousLocation` from the state is null or not.

```jsx
componentWillReceiveProps(nextProps: AfterpartyProps) {
  const navigated = nextProps.location !== this.props.location;
  if (navigated) {
    // save the location and data so we can render the old screen
    // first we try to use previousLocation and then location from props
    this.setState({
      previousLocation: this.state.previousLocation || this.props.location,
    });
```

currently when `getInitialProps` get resolved we do:
```js
window.scrollTo(0, 0);
this.setState({ previousLocation: null, data }); // `data` is result of `getInitialProps`
``` 
so `previousLocation` is null if we have `data` for current screen.

with these changes, when the user clicks on `<Link to="/post/1" />` and then `<Link to="/shop" />`
we can still show him/her the last screen with data (in our example it's "/" screen)

### One more thing

when that user clicks on a link to `/post/1`, that Promise was pending (and we are not going to cancel it), when it gets resolved it will change the `data` prop for "/" route, but we are not changing the component, so component for "/" route rendered with "/post/1" data, and this will break our app.

to fix this we simply check if the resolved promise is for the current location, if it was for another location we simply ignore it ...

```jsx
loadInitialProps(this.props.routes, nextProps.location.pathname, {
  location: nextProps.location,
  history: nextProps.history,
  ...rest
})
  .then(({ data }) => {
    // if data is not for current location just don't do anything
    if (location !== nextProps.location) {
      return  
    }
    window.scrollTo(0, 0);
    this.setState({ previousLocation: null, data });
  })
```
@Eddie-CooRo thanks for your help

## Breaking Changes
nothing :tada: 