### PR TITLE
Fixed broken predicate

### DIFF
--- a/src/ensureReady.ts
+++ b/src/ensureReady.ts
@@ -17,7 +17,7 @@ export async function ensureReady(routes: AsyncRouteProps[], pathname?: string) 
   );
 
   let data;
-  if (typeof window !== undefined && !!document) {
+  if (typeof window !== 'undefined' && !!document) {
     // deserialize state from 'serialize-javascript' format
     data = eval('(' + (document as any).getElementById('server-app-state').textContent + ')');
   }


### PR DESCRIPTION
`typeof` operator always returns a string.
This commit also fixes the `asyncComponent`s on SSR