### PR TITLE
Feature - Auto Scroll Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Next.js is awesome. However, its routing system isn't for me. IMHO React Router 
     - [Dynamic 404](#dynamic-404)
     - [Redirect](#redirect)
   - [Code Splitting](#code-splitting)
+  - [Disable Auto Scroll Globally](#disable-auto-scroll-globally)
   - [Custom `<Document>`](#custom-document)
   - [Custom/Async Rendering](#customasync-rendering)
   - [Author](#author)
@@ -108,6 +109,7 @@ the client and the server:
 - `match`: React Router's `match` object.
 - `history`: React Router's `history` object.
 - `location`: (client-only) React Router's `location` object (you can only use location.pathname on server).
+- `scrollToTop`: (client-only) React Ref object that controls scroll behavior when URL changes.
 
 ### Add Params to `getInitialProps: (ctx) => Data`
 
@@ -396,6 +398,38 @@ export default [
     }),
   },
 ];
+```
+
+## Disable Auto Scroll Globally
+
+By default after.js will scroll to top when url changes, you can change that by passing a ref object to <After />.
+
+```js
+// ./src/client.js
+
+const scrollToTop = React.createRef();
+scrollToTop.current = false; // this will disable scroll-to-top
+
+ensureReady(routes).then(data =>
+  hydrate(
+    <BrowserRouter>
+      <After data={data} routes={routes} scrollToTop={scrollToTop} />
+    </BrowserRouter>,
+    document.getElementById('root')
+  )
+);
+```
+
+We are using a ref object to minimize unnecessary re-renders, you can mutate ref.current and component will not re-rendered but its scroll behavior will change immediately.
+You can also control auto scroll behavior from `getInitialProps`.
+
+```js
+  static async getInitialProps({ req, res, match, history, location, scrollToTop, ...ctx }) {
+    if (scrollToTop) {
+      scrollToTop.current = false; // or true
+    }
+    return { stuff: 'whatevs' };
+  }
 ```
 
 ## Custom `<Document>`

--- a/README.md
+++ b/README.md
@@ -424,12 +424,12 @@ We are using a ref object to minimize unnecessary re-renders, you can mutate ref
 You can also control auto scroll behavior from `getInitialProps`.
 
 ```js
-  static async getInitialProps({ req, res, match, history, location, scrollToTop, ...ctx }) {
-    if (scrollToTop) {
-      scrollToTop.current = false; // or true
-    }
-    return { stuff: 'whatevs' };
+static async getInitialProps({ req, res, match, history, location, scrollToTop, ...ctx }) {
+  if (scrollToTop) {
+    scrollToTop.current = false; // or true
   }
+  return { scrollToTop, stuff: 'whatevs' }; // you can return scrollToTop and use it in your component
+}
 ```
 
 ## Custom `<Document>`

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Next.js is awesome. However, its routing system isn't for me. IMHO React Router 
     - [Dynamic 404](#dynamic-404)
     - [Redirect](#redirect)
   - [Code Splitting](#code-splitting)
-  - [Disable Auto Scroll Globally](#disable-auto-scroll-globally)
-  - [Disable Auto Scroll for a Specific Page](#disable-auto-scroll-for-a-specific-page)
+  - [Disable Auto-Scroll Globally](#disable-auto-scroll-globally)
+  - [Disable Auto-Scroll for a Specific Page](#disable-auto-scroll-for-a-specific-page)
   - [Custom `<Document>`](#custom-document)
   - [Custom/Async Rendering](#customasync-rendering)
   - [Author](#author)
@@ -105,12 +105,12 @@ export default About;
 Within `getInitialProps`, you have access to all you need to fetch data on both
 the client and the server:
 
-- `req?: Request`: (server-only) An Express.js request object
-- `res?: Response`: (server-only) An Express.js response object
+- `req?: Request`: (server-only) An Express.js request object.
+- `res?: Response`: (server-only) An Express.js response object.
 - `match`: React Router's `match` object.
 - `history`: React Router's `history` object.
 - `location`: (client-only) React Router's `location` object (you can only use location.pathname on server).
-- `scrollToTop`: (client-only) React Ref object that controls scroll behavior when URL changes.
+- `scrollToTop`: React Ref object that controls scroll behavior when URL changes.
 
 ### Add Params to `getInitialProps: (ctx) => Data`
 
@@ -401,9 +401,9 @@ export default [
 ];
 ```
 
-## Disable Auto Scroll Globally
+## Disable Auto-Scroll Globally
 
-By default After.js will scroll to top when url changes, you can change that by passing `scrollToTop: false` to render().
+By default, After.js will scroll to top when URL changes, you can change that by passing `scrollToTop: false` to render().
 
 ```js
 // ./src/server.js
@@ -419,10 +419,10 @@ const html = await render({
 });
 ```
 
-## Disable Auto Scroll for a Specific Page
+## Disable Auto-Scroll for a Specific Page
 
 We are using a ref object to minimize unnecessary re-renders, you can mutate scrollToTop.current and component will not re-rendered but its scroll behavior will change immediately.
-You can control auto scroll behavior from `getInitialProps`.
+You can control auto-scroll behavior from `getInitialProps`.
 
 ```js
 class MyComponent extends React.Component {

--- a/README.md
+++ b/README.md
@@ -426,15 +426,7 @@ You can control auto-scroll behavior from `getInitialProps`.
 
 ```js
 class MyComponent extends React.Component {
-  static async getInitialProps({
-    req,
-    res,
-    match,
-    history,
-    location,
-    scrollToTop,
-    ...ctx
-  }) {
+  static async getInitialProps({ scrollToTop }) {
     scrollToTop.current = false;
     return { scrollToTop, stuff: 'whatevs' };
   }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Next.js is awesome. However, its routing system isn't for me. IMHO React Router 
     - [Redirect](#redirect)
   - [Code Splitting](#code-splitting)
   - [Disable Auto Scroll Globally](#disable-auto-scroll-globally)
+  - [Disable Auto Scroll for a Specific Page](#disable-auto-scroll-for-a-specific-page)
   - [Custom `<Document>`](#custom-document)
   - [Custom/Async Rendering](#customasync-rendering)
   - [Author](#author)
@@ -402,33 +403,49 @@ export default [
 
 ## Disable Auto Scroll Globally
 
-By default After.js will scroll to top when url changes, you can change that by passing a ref object to `<After />`.
+By default After.js will scroll to top when url changes, you can change that by passing `scrollToTop: false` to render().
 
 ```js
-// ./src/client.js
+// ./src/server.js
 
-const scrollToTop = React.createRef();
-scrollToTop.current = false; // this will disable scroll-to-top
+const scrollToTop = false;
 
-ensureReady(routes).then(data =>
-  hydrate(
-    <BrowserRouter>
-      <After data={data} routes={routes} scrollToTop={scrollToTop} />
-    </BrowserRouter>,
-    document.getElementById('root')
-  )
-);
+const html = await render({
+  req,
+  res,
+  routes,
+  assets,
+  scrollToTop,
+});
 ```
 
-We are using a ref object to minimize unnecessary re-renders, you can mutate ref.current and component will not re-rendered but its scroll behavior will change immediately.
-You can also control auto scroll behavior from `getInitialProps`.
+## Disable Auto Scroll for a Specific Page
+
+We are using a ref object to minimize unnecessary re-renders, you can mutate scrollToTop.current and component will not re-rendered but its scroll behavior will change immediately.
+You can control auto scroll behavior from `getInitialProps`.
 
 ```js
-static async getInitialProps({ req, res, match, history, location, scrollToTop, ...ctx }) {
-  if (scrollToTop) {
-    scrollToTop.current = false; // or true
+class MyComponent extends React.Component {
+  static async getInitialProps({
+    req,
+    res,
+    match,
+    history,
+    location,
+    scrollToTop,
+    ...ctx
+  }) {
+    scrollToTop.current = false;
+    return { scrollToTop, stuff: 'whatevs' };
   }
-  return { scrollToTop, stuff: 'whatevs' }; // you can return scrollToTop and use it in your component
+
+  render() {
+    return <h1>Hello, World!</h1>;
+  }
+
+  componentWillUnmount() {
+    this.props.scrollToTop.current = true; // at the end restore scroll behavior
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ export default [
 
 ## Disable Auto Scroll Globally
 
-By default after.js will scroll to top when url changes, you can change that by passing a ref object to <After />.
+By default After.js will scroll to top when url changes, you can change that by passing a ref object to `<After />`.
 
 ```js
 // ./src/client.js

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -18,6 +18,7 @@ export interface AfterpartyProps extends RouteComponentProps<any> {
   data?: Promise<any>[];
   routes: AsyncRouteProps[];
   match: Match<any>;
+  scrollToTop?: boolean;
 }
 
 export interface AfterpartyState {
@@ -43,6 +44,10 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
     this.NotfoundComponent = get404Component(this.props.routes);
   }
 
+  static defaultProps = {
+    scrollToTop: true,
+  };
+
   // only runs clizzient
   componentWillReceiveProps(nextProps: AfterpartyProps) {
     const navigated = nextProps.location !== this.props.location;
@@ -60,6 +65,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
         history,
         location,
         staticContext,
+        scrollToTop,
         ...rest
       } = nextProps;
 
@@ -79,7 +85,9 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
           if (
             (this.state.previousLocation &&
               this.state.previousLocation.pathname) !==
-            nextProps.location.pathname
+              nextProps.location.pathname &&
+            // Only Scroll if scrollToTop is not false
+            nextProps.scrollToTop
           ) {
             window.scrollTo(0, 0);
           }

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -9,20 +9,19 @@ import {
 } from 'react-router-dom';
 import { loadInitialProps } from './loadInitialProps';
 import { History, Location } from 'history';
-import { AsyncRouteProps } from './types';
+import { AsyncRouteProps, ServerAppState, InitialData } from './types';
 import { get404Component, getAllRoutes } from './utils';
 
 export interface AfterpartyProps extends RouteComponentProps<any> {
   history: History;
   location: Location;
-  data?: Promise<any>[];
+  data: ServerAppState;
   routes: AsyncRouteProps[];
   match: Match<any>;
-  scrollToTop?: React.RefObject<boolean>;
 }
 
 export interface AfterpartyState {
-  data?: Promise<any>[];
+  data?: InitialData;
   previousLocation: Location | null;
 }
 
@@ -36,17 +35,13 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
     super(props);
 
     this.state = {
-      data: props.data,
+      data: props.data.initialData,
       previousLocation: null,
     };
 
     this.prefetcherCache = {};
     this.NotfoundComponent = get404Component(this.props.routes);
   }
-
-  static defaultProps = {
-    scrollToTop: { current: true } as React.RefObject<boolean>,
-  };
 
   // only runs clizzient
   componentWillReceiveProps(nextProps: AfterpartyProps) {
@@ -68,9 +63,12 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
         ...rest
       } = nextProps;
 
+      const { scrollToTop } = data.afterData;
+
       loadInitialProps(this.props.routes, nextProps.location.pathname, {
         location: nextProps.location,
         history: nextProps.history,
+        scrollToTop,
         ...rest,
       })
         .then(({ data }) => {
@@ -86,7 +84,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
               this.state.previousLocation.pathname) !==
               nextProps.location.pathname &&
             // Only Scroll if scrollToTop is not false
-            nextProps.scrollToTop!.current
+            nextProps.data.afterData.scrollToTop.current
           ) {
             window.scrollTo(0, 0);
           }

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -45,7 +45,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
   }
 
   static defaultProps = {
-    scrollToTop: { current: false } as React.RefObject<boolean>,
+    scrollToTop: { current: true } as React.RefObject<boolean>,
   };
 
   // only runs clizzient
@@ -65,7 +65,6 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
         history,
         location,
         staticContext,
-        scrollToTop,
         ...rest
       } = nextProps;
 

--- a/src/After.tsx
+++ b/src/After.tsx
@@ -18,7 +18,7 @@ export interface AfterpartyProps extends RouteComponentProps<any> {
   data?: Promise<any>[];
   routes: AsyncRouteProps[];
   match: Match<any>;
-  scrollToTop?: boolean;
+  scrollToTop?: React.RefObject<boolean>;
 }
 
 export interface AfterpartyState {
@@ -45,7 +45,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
   }
 
   static defaultProps = {
-    scrollToTop: true,
+    scrollToTop: { current: false } as React.RefObject<boolean>,
   };
 
   // only runs clizzient
@@ -87,7 +87,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
               this.state.previousLocation.pathname) !==
               nextProps.location.pathname &&
             // Only Scroll if scrollToTop is not false
-            nextProps.scrollToTop
+            nextProps.scrollToTop!.current
           ) {
             window.scrollTo(0, 0);
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,14 +8,27 @@ import { Request, Response } from 'express';
 import { IncomingMessage, ServerResponse } from 'http';
 import { History, Location } from 'history';
 
+export type InitialData = Promise<any>[];
+export type ScrollToTop = React.RefObject<boolean>;
+
+export interface ServerAppState {
+  afterData: AfterClientData;
+  initialData: InitialData;
+}
+
+export interface AfterClientData {
+  scrollToTop: ScrollToTop;
+}
+
 export interface DocumentProps {
   req: Request;
   res: Response;
   helmet: HelmetData;
   assets: Assets;
-  data: Promise<any>[];
+  data: ServerAppState;
   renderPage: () => Promise<any>;
   match: Match<any> | null;
+  scrollToTop: ScrollToTop;
 }
 
 export interface CtxBase {
@@ -23,7 +36,7 @@ export interface CtxBase {
   res?: ServerResponse;
   history?: History;
   location?: Location;
-  scrollToTop?: React.RefObject<boolean>;
+  scrollToTop?: ScrollToTop;
 }
 export interface Ctx<P> extends CtxBase {
   match: Match<P>;
@@ -58,7 +71,7 @@ export interface AsyncRouteProps<Props = any> extends RouteProps {
 
 export interface InitialProps {
   match?: AsyncRouteProps;
-  data: Promise<any>[];
+  data: InitialData;
 }
 
 export type Module<P> =

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface CtxBase {
   res?: ServerResponse;
   history?: History;
   location?: Location;
+  scrollToTop?: React.RefObject<boolean>;
 }
 export interface Ctx<P> extends CtxBase {
   match: Match<P>;


### PR DESCRIPTION
## Feature
Scroll behavior control.

## Current Behavior
When URL changes after.js automatically will scroll to top.

## Desired Behavior
Disable Scroll to top globally or conditionally for specific pages.

### Disable Auto-Scroll Globally

By default, After.js will scroll to top when URL changes, you can change that by passing `scrollToTop: false` to render().

```js
// ./src/server.js

const scrollToTop = false;

const html = await render({
  req,
  res,
  routes,
  assets,
  scrollToTop,
});
```

### Disable Auto-Scroll for a Specific Page

We are using a ref object to minimize unnecessary re-renders, you can mutate scrollToTop.current and component will not re-rendered but its scroll behavior will change immediately.
You can control auto-scroll behavior from `getInitialProps`.

```js
class MyComponent extends React.Component {
  static async getInitialProps({
    req,
    res,
    match,
    history,
    location,
    scrollToTop,
    ...ctx
  }) {
    scrollToTop.current = false;
    return { scrollToTop, stuff: 'whatevs' };
  }

  render() {
    return <h1>Hello, World!</h1>;
  }

  componentWillUnmount() {
    this.props.scrollToTop.current = true; // at the end restore scroll behavior
  }
}
```

## Breaking Changes
Nothing 🎉

## Additional Information
Closes: #258 