### PR TITLE
Fix Anchor Link Scrolling to Top on Click

### DIFF
--- a/packages/after.js/src/After.tsx
+++ b/packages/after.js/src/After.tsx
@@ -92,10 +92,10 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
 
           // Only for page changes, prevent scroll up for anchor links
           if (
-            (prevState.previousLocation &&
-              prevState.previousLocation.pathname) !== location.pathname &&
+            (prevState.currentLocation &&
+              prevState.currentLocation.pathname) !== location.pathname &&
             // Only Scroll if scrollToTop is not false
-            this.props.data.afterData.scrollToTop.current
+            scrollToTop.current
           ) {
             window.scrollTo(0, 0);
           }


### PR DESCRIPTION
Only scroll to the top if you have navigated to a new page and scrolling to the top is enabled.

Should have been using `prevState.currentLocation` instead on `prevState.previousLocation`. `prevState.previousLocation` appears to be `null`, resulting in a conditional like `(null && null) !== 'some path' && true`, which would evaluate to `true`.