### PR TITLE
[fix]: instant mode scroll to top

### DIFF
--- a/packages/after.js/src/After.tsx
+++ b/packages/after.js/src/After.tsx
@@ -77,6 +77,7 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
         history,
         routes,
         data,
+        transitionBehavior,
         // we don't want to pass these
         // to loadInitialProps()
         match,
@@ -86,6 +87,19 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
       } = this.props;
 
       const { scrollToTop } = data.afterData;
+
+      const instantMode = isInstantTransition(transitionBehavior)
+
+      // Only for page changes, prevent scroll up for anchor links
+      if (
+        (prevState.currentLocation &&
+          prevState.currentLocation.pathname) !== location.pathname &&
+        // Only Scroll if scrollToTop is not false
+        scrollToTop.current === true &&
+        instantMode === true
+      ) {
+        window.scrollTo(0, 0);
+      }
 
       loadInitialProps(routes, location.pathname, {
         location,
@@ -101,10 +115,12 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
             (prevState.currentLocation &&
               prevState.currentLocation.pathname) !== location.pathname &&
             // Only Scroll if scrollToTop is not false
-            scrollToTop.current
+            scrollToTop.current === true &&
+            instantMode === false
           ) {
             window.scrollTo(0, 0);
           }
+
           this.setState({ previousLocation: null, data, isLoading: false });
         })
         .catch(e => {

--- a/packages/after.js/src/After.tsx
+++ b/packages/after.js/src/After.tsx
@@ -132,12 +132,12 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
     const { location: currentLocation, transitionBehavior } = this.props;
     const initialData = this.prefetcherCache[currentLocation.pathname] || data;
 
-    const instantTransition = isInstantTransition(transitionBehavior)
+    const instantMode = isInstantTransition(transitionBehavior)
 
     // when we are in the instant mode we want to pass the right location prop
     // to the <Route /> otherwise it will render previous matche component
     const location =
-      instantTransition
+      instantMode
         ? currentLocation
         : previousLocation || currentLocation;
 


### PR DESCRIPTION
### Current Behaviour 

in blocked mode, `getInitialProps` gets called and then when the promise gets resolved we scroll to top
in instant mode, `getInitialProps` gets called and then when the promise gets resolved we scroll to top

### Expected Behaviour

in instant mode, call `getInitialProps` and at the same time scroll to top
in blocked mode, `getInitialProps` gets called and then when the promise gets resolved we scroll to top


> NOTE: you can always control scroll to top behavior with https://github.com/jaredpalmer/after.js#disable-auto-scroll-globally