### PR TITLE
Fixing comparison of pathname change for scroll to top feature

### DIFF
--- a/packages/after.js/src/After.tsx
+++ b/packages/after.js/src/After.tsx
@@ -112,8 +112,8 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
 
           // Only for page changes, prevent scroll up for anchor links
           if (
-            (prevState.currentLocation &&
-              prevState.currentLocation.pathname) !== location.pathname &&
+            prevState.currentLocation &&
+            prevState.currentLocation.pathname !== location.pathname &&
             // Only Scroll if scrollToTop is not false
             scrollToTop.current === true &&
             instantMode === false


### PR DESCRIPTION
Bug:
```javascript
(prevState.currentLocation && prevState.currentLocation.pathname) !== location.pathname
```

results to

```javascript
true !== location.pathname
// or 
false !== location.pathname
```

Just adding a simple fix:
```javascript
prevState.currentLocation && prevState.currentLocation.pathname !== location.pathname
```