### PR TITLE
Made transitionBehavior optional for Afterparty

### DIFF
--- a/packages/after.js/src/After.tsx
+++ b/packages/after.js/src/After.tsx
@@ -23,7 +23,7 @@ export interface AfterpartyProps extends RouteComponentProps<any> {
   data: ServerAppState;
   routes: AsyncRouteProps[];
   match: Match<any>;
-  transitionBehavior: TransitionBehavior;
+  transitionBehavior?: TransitionBehavior;
 }
 
 export interface AfterpartyState {


### PR DESCRIPTION
transitionBehavior already has a default value to 'blocking', so it should be optional.