### PR TITLE
fix: typescript interfaces & types

### DIFF
--- a/packages/after.js/src/After.tsx
+++ b/packages/after.js/src/After.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
+import { WithRouterStatics, Omit, WithRouterProps } from 'react-router';
 import {
   Switch,
   Route,
   withRouter,
   Redirect,
-  match as Match,
   RouteComponentProps,
 } from 'react-router-dom';
+import { Location } from 'history';
 import { loadInitialProps } from './loadInitialProps';
-import { History, Location } from 'history';
 import {
   AsyncRouteProps,
   ServerAppState,
@@ -20,11 +20,8 @@ import { get404Component, getAllRoutes, isInstantTransition } from './utils';
 import { loadStaticProps } from './loadStaticProps';
 
 export interface AfterpartyProps extends RouteComponentProps<any> {
-  history: History;
-  location: Location;
   data: ServerAppState;
   routes: AsyncRouteProps[];
-  match: Match<any>;
   transitionBehavior: TransitionBehavior;
 }
 
@@ -196,4 +193,12 @@ class Afterparty extends React.Component<AfterpartyProps, AfterpartyState> {
     );
   }
 }
-export const After = withRouter(Afterparty);
+
+type TAfterparty = React.ComponentClass<AfterpartyProps>;
+type TAfter = React.ComponentClass<
+  Omit<AfterpartyProps, keyof RouteComponentProps<any>> &
+    WithRouterProps<TAfterparty>
+> &
+  WithRouterStatics<TAfterparty>;
+
+export const After = withRouter(Afterparty) as TAfter;

--- a/packages/after.js/src/render.tsx
+++ b/packages/after.js/src/render.tsx
@@ -1,9 +1,9 @@
 import { renderApp } from './renderApp';
 import { AfterRenderOptions } from './types';
 
-export const render = async <T extends any>(
-  params: Omit<AfterRenderOptions<T>, 'ssg'>
-) => {
+type TRender = <T>(params: AfterRenderOptions<T>) => Promise<string>;
+
+export const render: TRender = async params => {
   const { res } = params;
   const { redirect, statusCode, html } = await renderApp({
     ...params,

--- a/packages/after.js/src/renderApp.tsx
+++ b/packages/after.js/src/renderApp.tsx
@@ -12,7 +12,7 @@ import {
   AfterClientData,
   CtxBase,
   AsyncRouteProps,
-  RedirectWithStatuCode,
+  RedirectWithStatusCode,
   ServerAppState,
   RenderResult,
   DocumentProps,
@@ -80,7 +80,7 @@ export async function renderApp<T>(
   // and see if it contains redirectTo or statusCode properties
   // we will mutate context if we got redirectTo or statusCode in initialData
   if (initialData) {
-    const { redirectTo, statusCode } = initialData as RedirectWithStatuCode;
+    const { redirectTo, statusCode } = initialData as RedirectWithStatusCode;
 
     if (statusCode) {
       context.statusCode = statusCode;

--- a/packages/after.js/src/renderStatic.tsx
+++ b/packages/after.js/src/renderStatic.tsx
@@ -1,9 +1,11 @@
 import { renderApp } from './renderApp';
-import { AfterRenderStaticOptions } from './types';
+import { AfterRenderStaticOptions, RenderResult } from './types';
 
-export const renderStatic = async <T extends any>(
+type TRenderStatic = <T extends any>(
   params: AfterRenderStaticOptions<T>
-) => {
+) => Promise<Pick<RenderResult, 'html' | 'data'>>;
+
+export const renderStatic: TRenderStatic = async params => {
   const { redirect, html, data } = await renderApp({ ...params, ssg: true });
 
   if (redirect) {

--- a/packages/after.js/src/types.ts
+++ b/packages/after.js/src/types.ts
@@ -50,7 +50,6 @@ export interface AsyncRouteComponentState {
 }
 
 export interface AsyncRouteProps<Props = any> extends RouteProps {
-  path?: string;
   Placeholder?: React.ComponentType<any>;
   component: AsyncRouteableComponent<Props>;
   redirectTo?: string;
@@ -58,8 +57,8 @@ export interface AsyncRouteProps<Props = any> extends RouteProps {
 
 export type ScrollToTop = React.RefObject<boolean>;
 
-// result of getInitalProps
-export type InitialData = Promise<unknown>[];
+// result of getInitialProps
+export interface InitialData {}
 
 export interface ServerAppState {
   afterData: AfterClientData;
@@ -91,7 +90,7 @@ export interface RenderResult {
 }
 
 // special result of getInitialProps
-export interface RedirectWithStatuCode {
+export interface RedirectWithStatusCode {
   statusCode?: number;
   redirectTo?: string;
 }
@@ -150,7 +149,7 @@ export type AfterContext = DocumentProps;
 // getAssets utility function
 export interface GetAssetsParams {
   chunks: Chunks;
-  route?: AsyncRouteProps<any>;
+  route?: AsyncRouteProps;
 }
 
 // ES Module type


### PR DESCRIPTION
- fix naming typos
- change InitialData type to interface for support declaration extends
- add types for render, renderStatic, After for support declaration extends
- remove path from AsyncRouteProps, because path can be is array